### PR TITLE
docs: change execution order of lint scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ pnpm-lock.yaml
 {
   "scripts": {
     "prepare": "husky install .husky",
-    "lint": "eslint --cache . && prettier --check --cache .",
-    "lint:fix": "eslint --fix --cache . && prettier --write --cache .",
+    "lint": "prettier --check --cache . && eslint --cache .",
+    "lint:fix": "prettier --write --cache . && eslint --fix --cache .",
   }
 }
 ```


### PR DESCRIPTION
If you are running `lint` or `lint:fix` locally and eslint fails because of linting errors, the whole script will fail and Prettier won't run. You get Prettier formatting only if you fix all eslint errors first. That's why Prettier should run prior to eslint.